### PR TITLE
Minor Changes

### DIFF
--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -584,9 +584,18 @@ export default class AgentClientPlugin extends Plugin {
 					? rawSettings.autoInstallAgents
 					: DEFAULT_SETTINGS.autoInstallAgents,
 			// Global API configuration
-			apiKey: DEFAULT_SETTINGS.apiKey,
-			baseUrl: DEFAULT_SETTINGS.baseUrl,
-			model: DEFAULT_SETTINGS.model,
+			apiKey:
+				typeof rawSettings.apiKey === "string"
+					? rawSettings.apiKey
+					: DEFAULT_SETTINGS.apiKey,
+			baseUrl:
+				typeof rawSettings.baseUrl === "string"
+					? rawSettings.baseUrl
+					: DEFAULT_SETTINGS.baseUrl,
+			model:
+				typeof rawSettings.model === "string"
+					? rawSettings.model
+					: DEFAULT_SETTINGS.model,
 		};
 
 		this.ensureActiveAgentId();

--- a/styles.css
+++ b/styles.css
@@ -394,6 +394,7 @@ If your plugin does not need CSS, delete this file.
 
 .obsidianaitools-chat-view-header-title {
 	margin: 0 !important;
+	color: #c97c59;
 }
 
 .obsidianaitools-chat-view-header-update {


### PR DESCRIPTION
## Description

src/plugin.ts to check rawSettings for API Key, URL and Model
It wasn't saving Obsidian AI Tools API Key and showing welcome screen every time you load Obsidian
Changed the Claude Code Text to Orange in CSS File

## Related issue

None

## Type of change

- [ x ] Bug fix
- [ x ] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Other

## Checklist

- [ x ] Tested in Obsidian
- [ x ] Existing functionality still works

## Testing environment

- Agent: Claude Code
- OS: Windows 11 

## Screenshots

<img width="1069" height="1944" alt="image" src="https://github.com/user-attachments/assets/3f137ab9-4bc4-49b7-a2d1-105cfcef88ae" />


