### PR TITLE
Fix CI lint errors: console.log, async onClick, type assertion

### DIFF
--- a/dev-logs/2026-02-13-repair-orphaned-session-metadata.md
+++ b/dev-logs/2026-02-13-repair-orphaned-session-metadata.md
@@ -55,8 +55,27 @@ Added a `repairSessionMetadata()` method that runs on plugin startup, scans the 
 - Changed label from "Fork session (create new branch)" to "Duplicate session".
 - Rationale: "Fork" and "branch" are git terminology unfamiliar to most users. "Duplicate" is clearer for the actual behavior (copying a session to continue independently).
 
+## CI Lint Fixes (February 14, 2026)
+
+Pull request #11 failed CI due to lint errors. Fixed the following:
+
+**`src/plugin.ts`** (7 errors)
+- Changed all `console.log()` calls to `console.debug()`. ESLint rule only allows `warn`, `error`, `debug`.
+
+**`src/components/chat/PermissionRequestSection.tsx`** (1 error)
+- `onClick={handleSubmitCustomText}` passed a Promise-returning async function where void was expected.
+- Fixed: `onClick={() => void handleSubmitCustomText()}`
+
+**`src/adapters/obsidian/settings-store.adapter.ts`** (1 error)
+- `textContent.text as string` — unnecessary type assertion since `.text` is already typed as `string`.
+- Fixed: removed `as string`.
+
+**OnboardingModal.ts** (warnings only, not errors)
+- 10+ sentence-case warnings for UI text containing proper nouns (WSL, Node.js, API, etc.). These are correct as-is — rule is set to `warn` and won't fail CI.
+
 ## Verification
 
+- Lint passes: 0 errors, 70 warnings (all sentence-case, non-blocking).
 - Build succeeds (`npm run build`).
 - On next Obsidian reload, orphaned session files in `sessions/` will be detected and their metadata rebuilt into `savedSessions`.
 - Existing sessions with valid metadata are not duplicated (checked via `existingIds` Set).

--- a/src/adapters/obsidian/settings-store.adapter.ts
+++ b/src/adapters/obsidian/settings-store.adapter.ts
@@ -431,7 +431,7 @@ export class SettingsStore implements ISettingsAccess {
 						(c) => c.type === "text",
 					);
 					if (textContent && "text" in textContent) {
-						const text = textContent.text as string;
+						const text = textContent.text;
 						title =
 							text.length > 50
 								? text.substring(0, 50) + "..."

--- a/src/components/chat/PermissionRequestSection.tsx
+++ b/src/components/chat/PermissionRequestSection.tsx
@@ -150,7 +150,7 @@ export function PermissionRequestSection({
 								</button>
 								<button
 									className="obsidianaitools-permission-other-submit"
-									onClick={handleSubmitCustomText}
+									onClick={() => void handleSubmitCustomText()}
 									disabled={!customText.trim() || isSubmitting}
 								>
 									{isSubmitting ? "Sending..." : "Send & Reject"}

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -140,19 +140,19 @@ export default class AgentClientPlugin extends Plugin {
 
 	async onload() {
 		try {
-			console.log("[AI Tools] Loading plugin...");
+			console.debug("[AI Tools] Loading plugin...");
 
 			// Register view FIRST (synchronous) - must happen before any async
 			// operations so Obsidian can restore saved workspace layout immediately
 			this.registerView(VIEW_TYPE_CHAT, (leaf) => new ChatView(leaf, this));
-			console.log("[AI Tools] View registered");
+			console.debug("[AI Tools] View registered");
 
 			await this.loadSettings();
-			console.log("[AI Tools] Settings loaded successfully");
+			console.debug("[AI Tools] Settings loaded successfully");
 
 			// Initialize settings store
 			this.settingsStore = createSettingsStore(this.settings, this);
-			console.log("[AI Tools] Settings store initialized");
+			console.debug("[AI Tools] Settings store initialized");
 
 			// Repair orphaned session metadata (fire-and-forget)
 			const vaultBasePath =
@@ -162,7 +162,7 @@ export default class AgentClientPlugin extends Plugin {
 				.repairSessionMetadata(vaultBasePath)
 				.then((count) => {
 					if (count > 0) {
-						console.log(
+						console.debug(
 							`[AI Tools] Repaired ${count} orphaned session(s)`,
 						);
 					}
@@ -204,7 +204,7 @@ export default class AgentClientPlugin extends Plugin {
 			// Register agent-specific commands
 			this.registerAgentCommands();
 			this.registerPermissionCommands();
-			console.log("[AI Tools] Commands registered");
+			console.debug("[AI Tools] Commands registered");
 
 			this.addSettingTab(new AgentClientSettingTab(this.app, this));
 
@@ -223,7 +223,7 @@ export default class AgentClientPlugin extends Plugin {
 					}
 				}),
 			);
-			console.log("[AI Tools] Plugin loaded successfully ✓");
+			console.debug("[AI Tools] Plugin loaded successfully");
 		} catch (error) {
 			console.error("[AI Tools] Failed to initialize plugin:", error);
 			new Notice(


### PR DESCRIPTION
## Summary

Fix CI lint errors that caused PR #11 to fail.

- `console.log` → `console.debug` in plugin.ts (eslint only allows warn/error/debug)
- Wrap async `onClick` handler with `void` in PermissionRequestSection.tsx
- Remove unnecessary `as string` type assertion in settings-store.adapter.ts

## Type of change

- [x] Bug fix

## Checklist

- [x] `npm run lint` passes (0 errors, warnings are sentence-case for brand names)
- [x] `npm run build` passes
